### PR TITLE
pkg_pretend: Binary packages also call this function

### DIFF
--- a/ebuild-writing/functions/pkg_pretend/text.xml
+++ b/ebuild-writing/functions/pkg_pretend/text.xml
@@ -23,7 +23,7 @@
   </tr>
   <tr>
     <th>Called for</th>
-    <ti>ebuild</ti>
+    <ti>ebuild, binary</ti>
   </tr>
   <tr>
     <th>EAPI</th>


### PR DESCRIPTION
Proof: Create a dummy ebuild with
  ```
  pkg_pretend() {
          echo "Calling pkg_pretend()..."
  }
  ```

Now create the binary package:
  ```
  # emerge --buildpkgonly app-misc/testpkg::my-overlay

  These are the packages that would be built, in order:

  Calculating dependencies... done!
  [ebuild  N    *] app-misc/testpkg-0.0.1::my-overlay  0 KiB

  Total: 1 package (1 new), Size of downloads: 0 KiB

  >>> Verifying ebuild manifests
  >>> Running pre-merge checks for app-misc/testpkg-0.0.1
  Calling pkg_pretend()...

  [...]
  ```
When you now install the binary package, pkg_pretend() will be called again:
  ```
  # emerge --usepkg=y -a1 app-misc/testpkg::my-overlay

  These are the packages that would be merged, in order:

  Calculating dependencies... done!
  [binary  N    *] app-misc/testpkg-0.0.1::my-overlay  0 KiB

  Total: 1 package (1 new, 1 binary), Size of downloads: 0 KiB

  Would you like to merge these packages? [Yes/No] y
  >>> Running pre-merge checks for app-misc/testpkg-0.0.1
   * testpkg-0.0.1.tbz2 MD5 SHA1 size ;-) ...              [ ok ]
  Calling pkg_pretend()...

  [...]
  ```