### PR TITLE
Update bash command

### DIFF
--- a/ebuild-writing/file-format/text.xml
+++ b/ebuild-writing/file-format/text.xml
@@ -138,7 +138,7 @@ is to use <c>9999</c> as the version (or as the last version component).
 <p>
 All ebuilds committed to the tree should have a three line header immediately at
 the start indicating copyright. This must be an exact copy of the contents of
-<c>$(portageq portdir)/header.txt</c>. Ensure that the <c>$Header: $</c> line is not
+<c>$(portageq get_repo_path / gentoo)/header.txt</c>. Ensure that the <c>$Header: $</c> line is not
 modified manually <d/> CVS will handle this line specially.
 </p>
 


### PR DESCRIPTION
Using of `$(portageq portdir)/header.txt` throws warning:
> WARNING: 'portageq portdir' is deprecated. Use the get_repo_path command instead. eg: 'portageq get_repo_path / gentoo' instead.