### PR TITLE
Consistent EAPI declaration

### DIFF
--- a/ebuild-writing/functions/src_prepare/epatch/text.xml
+++ b/ebuild-writing/functions/src_prepare/epatch/text.xml
@@ -8,7 +8,7 @@
 The canonical way of applying patches in ebuilds is to
 use <c>epatch</c> (from <c>eutils.eclass</c>, which you must make sure
 to import!) inside <c>src_prepare</c>. This function automatically
-handles <c>-p</c> levels, <c>gunzip</c> and so on as necessary. Also note that olds ebuild may still use src_unpack to apply patches. This is because those ebuilds are based in EAPI="1". You are advised to use EAPI="2" and apply your patches in src_prepare function instead.
+handles <c>-p</c> levels, <c>gunzip</c> and so on as necessary. Also note that olds ebuild may still use src_unpack to apply patches. This is because those ebuilds are based in EAPI=1. You are advised to use EAPI=2 and apply your patches in src_prepare function instead.
 </p>
 
 <p>

--- a/ebuild-writing/functions/src_prepare/text.xml
+++ b/ebuild-writing/functions/src_prepare/text.xml
@@ -32,7 +32,7 @@
 <title>Default <c>src_prepare</c></title>
 <body>
 <p>
-Starting from EAPI="2", the src_prepare function is the appropriate area to perform
+Starting from EAPI=2, the src_prepare function is the appropriate area to perform
 any kind of patching and source code manipulation, instead of src_unpack.
 </p>
 <codesample lang="ebuild">

--- a/ebuild-writing/using-eclasses/text.xml
+++ b/ebuild-writing/using-eclasses/text.xml
@@ -34,7 +34,7 @@ After inheriting an eclass, its provided functions can be used as normal. Here's
 # Distributed under the terms of the GNU General Public License v2
 # $Header: $
 
-EAPI="2"
+EAPI=2
 
 inherit eutils bash-completion flag-o-matic autotools
 

--- a/general-concepts/autotools/text.xml
+++ b/general-concepts/autotools/text.xml
@@ -124,7 +124,7 @@ either <c>Makefile.am</c> or <c>configure.ac</c>:
 </p>
 
 <codesample lang="ebuild">
-EAPI="5"
+EAPI=5
 
 inherit autotools
 

--- a/general-concepts/dependencies/text.xml
+++ b/general-concepts/dependencies/text.xml
@@ -229,7 +229,7 @@ RDEPEND="!!app-misc/foo"
 </codesample>
 
 <p>
-Hardblockers always take precedence over softblockers and need at least EAPI="2".
+Hardblockers always take precedence over softblockers and need at least EAPI=2.
 Also note that blockers are usually <e>runtime</e> rather than buildtime.
 </p>
 
@@ -268,7 +268,7 @@ newer package that caused the issues.
 
 <p>
 In order to depend on a package in a specific <c>SLOT</c> you must specify
-at least <c>EAPI="1"</c>.
+at least <c>EAPI=1</c>.
 </p>
 
 <p>
@@ -295,7 +295,7 @@ DEPEND="qt3? ( ~x11-libs/qt-3.3.8:3 )
 <body>
 
 <p>
-In <c>EAPI="5"</c> and higher, you can use slot operators appended to the package
+In <c>EAPI=5</c> and higher, you can use slot operators appended to the package
 name to declare whether or not your package should be rebuilt after the versions
 satisfying its runtime dependencies are updated to versions with a different slot
 or <uri link="::general-concepts/slotting#Sub-Slots">sub-slot</uri>:
@@ -442,7 +442,7 @@ flag is not necessary if and only if all of the following hold:
 <body>
 
 <p>
-In order to use built with use dependencies you must specify <c>EAPI="2"</c>.
+In order to use built with use dependencies you must specify <c>EAPI=2</c>.
 </p>
 
 <p>


### PR DESCRIPTION
Most of occurrence of the EAPI declarations are without the quotes, so align
the rest for more consistency.