### PR TITLE
Add src_configure to the list of called functions

### DIFF
--- a/ebuild-writing/functions/text.xml
+++ b/ebuild-writing/functions/text.xml
@@ -6,10 +6,10 @@
 <body>
 <p>
 When installing packages from source, the function call order is <c>pkg_setup</c>,
-<c>src_unpack</c>, <c>src_prepare</c>, <c>src_compile</c>, <c>src_test</c> (optional, <c>FEATURES="test"</c>),
-<c>src_install</c>, <c>pkg_preinst</c>, <c>pkg_postinst</c>. When installing packages
-from a binary, the function call order is <c>pkg_setup</c>, <c>pkg_preinst</c>,
-<c>pkg_postinst</c>.
+<c>src_unpack</c>, <c>src_prepare</c>, <c>src_configure</c>, <c>src_compile</c>,
+<c>src_test</c> (optional, <c>FEATURES="test"</c>), <c>src_install</c>, <c>pkg_preinst</c>,
+<c>pkg_postinst</c>. When installing packages from a binary, the function call order is
+<c>pkg_setup</c>, <c>pkg_preinst</c>, <c>pkg_postinst</c>.
 As some phases haven't been introduced from the beginning, you can have a look at
 <uri link="::ebuild-writing/eapi"/> for an overview, what have been introduced in which EAPI.
 </p>


### PR DESCRIPTION
src_configure is missing from the list of called functions when installing from source
Also, rebalance line length a bit