### PR TITLE
typo corrected

### DIFF
--- a/ebuild-writing/eapi/text.xml
+++ b/ebuild-writing/eapi/text.xml
@@ -973,7 +973,7 @@ src_install() {
 	<li>
 		<p><b><c>unpack</c> changes</b></p>
 		<ul>
-			<li><p><c>unpack</c> supports elative paths without leading <c>./</c> (<c>unpack foo/bar.tar.gz</c> is valid as relative path).</p></li>
+			<li><p><c>unpack</c> supports relative paths without leading <c>./</c> (<c>unpack foo/bar.tar.gz</c> is valid as relative path).</p></li>
 			<li><p><c>unpack</c> supports <c>.txz</c> (xz compressed tarball).</p></li>
 			<li><p><c>unpack</c> matches filename extensions case-insensitively.</p></li>
 		</ul>


### PR DESCRIPTION
last section describing EAPI=6, under Helpers subsection in unpack changes the first point has a typo.

>unpack supports "elative" paths without leading ./ (unpack foo/bar.tar.gz is valid as relative path).