### PR TITLE
Fix a typo, update copyright year and replace an instance of 'herd' with 'project'

### DIFF
--- a/ebuild-maintenance/text.xml
+++ b/ebuild-maintenance/text.xml
@@ -281,7 +281,7 @@ which is often more convenient.
 <section>
 <title>Touching other developers ebuilds</title>
 <body>
-<p>Usually you don't just change other developers ebuilds without permission unless you know that developer does not mind or if you are part of the herd involved in maintenance (this information can typically be found in metadata.xml). Start with filing a bug or trying to catch them on IRC or via email. Sometimes you cannot reach them, or there is no response to your bug. It's a good idea to consult other developers on how to handle the situation, especially if it's a critical issue that needs to be handled ASAP. Otherwise a soft limit of 2 to 4 weeks depending on the severity of the bug is an acceptable time frame before you go ahead and fix it yourself.</p> 
+<p>Usually you don't just change other developers ebuilds without permission unless you know that developer does not mind or if you are part of the project involved in maintenance (this information can typically be found in metadata.xml). Start with filing a bug or trying to catch them on IRC or via email. Sometimes you cannot reach them, or there is no response to your bug. It's a good idea to consult other developers on how to handle the situation, especially if it's a critical issue that needs to be handled ASAP. Otherwise a soft limit of 2 to 4 weeks depending on the severity of the bug is an acceptable time frame before you go ahead and fix it yourself.</p> 
 <important> Common sense dictates to us that toolchain/base-system/core packages and eclasses or anything else which is delicate (e.g. glibc) or widely used (e.g. gtk+) should usually be left to those maintainers. If in doubt, don't touch it.</important>
 
 <p>

--- a/ebuild-writing/common-mistakes/text.xml
+++ b/ebuild-writing/common-mistakes/text.xml
@@ -158,7 +158,7 @@ The first three lines <e>must</e> look like this:
 </p>
 
 <pre caption="Valid Header">
-# Copyright 1999-2015 Gentoo Foundation
+# Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 # &#36;Id&#36;
 </pre>

--- a/ebuild-writing/eapi/text.xml
+++ b/ebuild-writing/eapi/text.xml
@@ -42,7 +42,7 @@ Most developers prefer to set the EAPI version without quotes. However, the PMS 
 </note>
 
 <codesample lang="ebuild">
-# Copyright 1999-2015 Gentoo Foundation
+# Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 # $Id$
 
@@ -120,7 +120,7 @@ src_compile() {
 		</important>
 
 		<codesample lang="ebuild">
-# Copyright 1999-2015 Gentoo Foundation
+# Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 # $Id$
 
@@ -515,7 +515,7 @@ DEPEND="
 		</p>
 		<p>Example:</p>
 		<codesample lang="ebuild">
-# Copyright 1999-2015 Gentoo Foundation
+# Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 # $Id$
 

--- a/ebuild-writing/eapi/text.xml
+++ b/ebuild-writing/eapi/text.xml
@@ -14,7 +14,7 @@ down and agreed upon.
 
 <p>
 EAPI is a version defined in ebuilds and other package manager related files
-which inform the package manager about the file syntax and content. It is,
+which informs the package manager about the file syntax and content. It is,
 in effect, the version of the package manager specification (PMS) that the
 file adheres to.
 </p>

--- a/ebuild-writing/file-format/text.xml
+++ b/ebuild-writing/file-format/text.xml
@@ -143,7 +143,7 @@ modified manually <d/> will be expanded on staging box. See <uri link="::general
 </p>
 
 <codesample lang="ebuild">
-# Copyright 1999-2015 Gentoo Foundation
+# Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 # $Id$
 </codesample>

--- a/ebuild-writing/functions/src_unpack/rpm-sources/text.xml
+++ b/ebuild-writing/functions/src_unpack/rpm-sources/text.xml
@@ -52,7 +52,7 @@ patches. The filename should be <c>suse-fetchmail-6.2.5.54.1.ebuild</c>.
 </p>
 
 <codesample lang="ebuild">
-# Copyright 1999-2015 Gentoo Foundation
+# Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 # $Id$
 

--- a/ebuild-writing/using-eclasses/text.xml
+++ b/ebuild-writing/using-eclasses/text.xml
@@ -30,7 +30,7 @@ After inheriting an eclass, its provided functions can be used as normal. Here's
 </p>
 
 <codesample lang="ebuild">
-# Copyright 1999-2015 Gentoo Foundation
+# Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 # $Id$
 

--- a/ebuild-writing/using-eclasses/text.xml
+++ b/ebuild-writing/using-eclasses/text.xml
@@ -26,7 +26,7 @@ link="::general-concepts/portage-cache"/>).
 </p>
 
 <p>
-After inheriting an eclass, its provided functions can be used as normal. Here'san example ebuild, <c>foomatic-0.1-r2.ebuild</c>, which uses four eclasses:
+After inheriting an eclass, its provided functions can be used as normal. Here's an example ebuild, <c>foomatic-0.1-r2.ebuild</c>, which uses four eclasses:
 </p>
 
 <codesample lang="ebuild">

--- a/eclass-writing/text.xml
+++ b/eclass-writing/text.xml
@@ -176,7 +176,7 @@ a single function, <c>domacosapp</c>.
 </p>
 
 <codesample lang="ebuild">
-# Copyright 1999-2015 Gentoo Foundation
+# Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 # $Id$
 
@@ -263,7 +263,7 @@ something like the following:
 </p>
 
 <codesample lang="ebuild">
-# Copyright 1999-2015 Gentoo Foundation
+# Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 # $Id$
 
@@ -306,7 +306,7 @@ for an eclass to invoke die from the global scope.  For example:
 </p>
 
 <codesample lang="ebuild">
-# Copyright 1999-2015 Gentoo Foundation
+# Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 # $Id$
 

--- a/quickstart/text.xml
+++ b/quickstart/text.xml
@@ -34,7 +34,7 @@ can see real ebuilds in the main tree).
 </p>
 
 <codesample lang="ebuild">
-# Copyright 1999-2015 Gentoo Foundation
+# Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 # $Id$
 
@@ -206,7 +206,7 @@ Here's <c>app-misc/detox/detox-1.1.1.ebuild</c>:
 </p>
 
 <codesample lang="ebuild">
-# Copyright 1999-2015 Gentoo Foundation
+# Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 # $Id$
 
@@ -271,7 +271,7 @@ this is done via <c>inherit eutils</c> at the top of the ebuild. Here's
 </p>
 
 <codesample lang="ebuild">
-# Copyright 1999-2015 Gentoo Foundation
+# Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 # $Id$
 
@@ -329,7 +329,7 @@ replacement iconv for <c>libc</c> implementations which don't have their own.
 </p>
 
 <codesample lang="ebuild">
-# Copyright 1999-2015 Gentoo Foundation
+# Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 # $Id$
 
@@ -373,7 +373,7 @@ Another more complicated example, this time based upon
 </p>
 
 <codesample lang="ebuild">
-# Copyright 1999-2015 Gentoo Foundation
+# Copyright 1999-2016 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 # $Id$
 


### PR DESCRIPTION
This will not fix all occurrences of 'herd' but it is a start.