### PR TITLE
function-reference/build-install-functions: removed banned dohard, added specific eapi ban notes for einstall and dohtml, #564620

### DIFF
--- a/function-reference/build-functions/text.xml
+++ b/function-reference/build-functions/text.xml
@@ -49,6 +49,7 @@ during the unpack and compile stages.
     </ti>
     <ti>
       Wrapper for <c>emake install</c>, only to be used if <c>emake DESTDIR="${D}"</c> is unsuitable.
+      <b>Note</b>: Banned in EAPI 6.
     </ti>
   </tr>
 </table>

--- a/function-reference/install-functions/text.xml
+++ b/function-reference/install-functions/text.xml
@@ -144,14 +144,6 @@ the first is the source name, the second the name to use when installing.
   </tr>
   <tr>
     <ti>
-      <c>dohard</c>
-    </ti>
-    <ti>
-      Create a hardlink to the first argument from the second argument
-    </ti>
-  </tr>
-  <tr>
-    <ti>
       <c>doheader</c>
     </ti>
     <ti>
@@ -164,6 +156,7 @@ the first is the source name, the second the name to use when installing.
     </ti>
     <ti>
       Installs HTML document files into <c>/usr/share/doc/${PF}/html</c>
+      <b>Note</b>: Banned in EAPI 7.
     </ti>
   </tr>
   <tr>

--- a/function-reference/install-functions/text.xml
+++ b/function-reference/install-functions/text.xml
@@ -156,7 +156,7 @@ the first is the source name, the second the name to use when installing.
     </ti>
     <ti>
       Installs HTML document files into <c>/usr/share/doc/${PF}/html</c>
-      <b>Note</b>: Banned in EAPI 7.
+      <b>Note</b>: Deprecated in EAPI 6.
     </ti>
   </tr>
   <tr>


### PR DESCRIPTION
Gentoo-Bug: https://bugs.gentoo.org/show_bug.cgi?id=564620

Considered the latest PMS in which EAPI 0-3 are banned in Gentoo. 
- dohard is banned in EAPI 4, and should not be used and (like dosed already) be removed from the devmanual
- dohtml and einstall could still be used in valid EAPI's, just a note for those