### PR TITLE
function-reference/query-functions: add has_version flag explanation, bug #307065

### DIFF
--- a/function-reference/query-functions/text.xml
+++ b/function-reference/query-functions/text.xml
@@ -105,9 +105,9 @@ query variables and similar state.
       <c>has_version pkg[flag]</c>
     </ti>
     <ti>
-      True if <c>pkg</c> (can include version specifiers) is installed. The use of <c>flag</c> is
-      optional and <c>flag</c> can be a list of multiple USE flags. Example:
-      <c>if has_version "=app-editors/nano-2.5.3"["nls,spell"] ; then</c>.
+      True if <c>pkg</c> (can include version specifiers and 
+      <uri link="::general-concepts/dependencies#built with use dependencies"/>) is installed. 
+      Example: <c>if has_version "=app-editors/nano-2.5.3[nls,spell]" ; then</c>.
     </ti>
   </tr>
 </table>

--- a/function-reference/query-functions/text.xml
+++ b/function-reference/query-functions/text.xml
@@ -102,10 +102,12 @@ query variables and similar state.
   </tr>
   <tr>
     <ti>
-      <c>has_version pkg</c>
+      <c>has_version pkg[flag]</c>
     </ti>
     <ti>
-      True if <c>pkg</c> (can include version specifiers) is installed.
+      True if <c>pkg</c> (can include version specifiers) is installed. The use of <c>flag</c> is
+      optional and <c>flag</c> can be a list of multiple USE flags. Example:
+      <c>if has_version "=app-editors/nano-2.5.3"["nls,spell"] ; then</c>.
     </ti>
   </tr>
 </table>


### PR DESCRIPTION
Gentoo-Bug: https://bugs.gentoo.org/show_bug.cgi?id=307065

Added functionality as described in the bugreport, as well as adding a full example.