### PR TITLE
function-reference/install-functions: improve difference between doexe and dobin

### DIFF
--- a/function-reference/install-functions/text.xml
+++ b/function-reference/install-functions/text.xml
@@ -99,8 +99,8 @@ the first is the source name, the second the name to use when installing.
       <c>dobin</c>
     </ti>
     <ti>
-      Install a binary into <c>/usr/bin</c>, set it to mode 0755 and
-      set ownership to the superuser
+      Install a binary into <c>/usr/bin</c>, set the file mode to 0755
+      and set the ownership to superuser
     </ti>
   </tr>
   <tr>

--- a/function-reference/install-functions/text.xml
+++ b/function-reference/install-functions/text.xml
@@ -99,7 +99,8 @@ the first is the source name, the second the name to use when installing.
       <c>dobin</c>
     </ti>
     <ti>
-      Install a binary
+      Install a binary into <c>/usr/bin</c>, set it to mode 0755 and
+      set ownership to the superuser
     </ti>
   </tr>
   <tr>
@@ -139,7 +140,9 @@ the first is the source name, the second the name to use when installing.
       <c>doexe</c>
     </ti>
     <ti>
-      Install an executable
+      Install an executable into the location provided by <c>exeinto</c>,
+      by default with mode 0755 or with the install options set by
+      <c>exeopts</c>
     </ti>
   </tr>
   <tr>


### PR DESCRIPTION
Gentoo-Bug: https://bugs.gentoo.org/show_bug.cgi?id=586632

Tried to make the explanations as concise as possible (and not verbatim copy the PMS texts).