### PR TITLE
Portage is the package manager. The repository is named gentoo.

### DIFF
--- a/ebuild-maintenance/text.xml
+++ b/ebuild-maintenance/text.xml
@@ -15,14 +15,14 @@ developers may not be familiar with.
 <body>
 
 <subsection>
-<title>What (not) to put in the Portage tree</title>
+<title>What (not) to put in the Gentoo repository</title>
 <body>
 
 <p>
 Before writing a new ebuild, check
 <uri link="https://bugs.gentoo.org/">bugs.gentoo.org</uri>
 to see if an ebuild has already been written for the package, but has not yet
-been added to the Portage tree.  Go to <uri
+been added to the Gentoo repository.  Go to <uri
 link="https://bugs.gentoo.org/">bugs.gentoo.org</uri>, choose query and select
 Advanced Search; as product select <e>Gentoo Linux</e>, as component select
 <e>ebuilds</e>.  In the search field put the name of the ebuild and as status
@@ -31,7 +31,7 @@ select all possible fields, then submit the query. For you lazy people, click
 </p>
 
 <p>
-In general, the Portage tree should only be used for storing
+In general, the Gentoo repository should only be used for storing
 <path>.ebuild</path> files, as well as any relatively small companion
 files, such as patches or sample configuration files.  These types of
 files should be placed in the <path>/usr/portage/mycat/mypkg/files</path>
@@ -513,7 +513,7 @@ Date:   Tue Nov 3 20:26:52 2015 +0100
 <p>
 The process for changing the ebuild's SLOT is very similar to the previous process.
 Besides changing the SLOT in the ebuild file, you also need to create a new entry
-in <path>profiles/updates/</path> in the Portage tree in the following format:
+in <path>profiles/updates/</path> in the Gentoo repository in the following format:
 </p>
 
 <pre caption="Adding an entry to updates">

--- a/ebuild-writing/eapi/text.xml
+++ b/ebuild-writing/eapi/text.xml
@@ -7,7 +7,7 @@
 <p>
 The Package Manager Specification (PMS) is a standardization
 effort to ensure that the ebuild file format, the ebuild repository format
-(of which the portage tree is Gentoo's main incarnation) as well as behavior
+(of which the Gentoo repository is Gentoo's main incarnation) as well as behavior
 of the package managers interacting with these ebuilds is properly written
 down and agreed upon.
 </p>

--- a/general-concepts/dependencies/text.xml
+++ b/general-concepts/dependencies/text.xml
@@ -359,7 +359,7 @@ RDEPEND="!crypt? ( net-misc/netkit-rsh )"
 This should <b>not</b> be used for disabling a certain <c>USE</c> flag on a given
 architecture. In order to do this, the architecture team should add the <c>USE</c>
 flag to their <c>use.mask</c> file in the <c>profiles/arch</c>
-directory of the Portage tree.
+directory of the Gentoo repository.
 </p>
 
 <p>

--- a/general-concepts/licenses/text.xml
+++ b/general-concepts/licenses/text.xml
@@ -7,7 +7,7 @@
 <p>
 All ebuilds must specify a <c>LICENSE</c> (note the American English
 spelling) variable. The value of this variable must be the name of a
-file in the Portage tree's <c>licenses/</c> directory.
+file in the Gentoo repository's <c>licenses/</c> directory.
 </p>
 
 <p>

--- a/general-concepts/overlay/text.xml
+++ b/general-concepts/overlay/text.xml
@@ -40,7 +40,7 @@ override existing entries.
 <p>
 Be very careful when using eclasses in an overlay. Portage will not do cache
 updates when an overlay eclass is changed, nor will it do cache updates when a
-main Portage tree eclass which is used by an overlay ebuild changes. You may
+main Gentoo repository eclass which is used by an overlay ebuild changes. You may
 also encounter bogus 'illegal inherit' notices when working with eclasses in
 an overlay (see <uri
 link="::appendices/common-problems/#QA Notice -- ECLASS foo inherited illegally"/>).

--- a/general-concepts/text.xml
+++ b/general-concepts/text.xml
@@ -6,7 +6,7 @@
 <body>
 <p>
 This section covers some general concepts with which you should be familiar when
-writing ebuilds or working with the Portage tree.
+writing ebuilds or working with the Gentoo repository.
 </p>
 </body>
 

--- a/general-concepts/tree/text.xml
+++ b/general-concepts/tree/text.xml
@@ -1,11 +1,11 @@
 <?xml version="1.0"?>
 <guide self="general-concepts/tree/">
 <chapter>
-<title>The Portage Tree</title>
+<title>The Gentoo Repository</title>
 
 <body>
 <p>
-The basic layout of the portage tree is as follows:
+The basic layout of the Gentoo repository is as follows:
 </p>
 
 <ul>

--- a/general-concepts/virtuals/text.xml
+++ b/general-concepts/virtuals/text.xml
@@ -38,7 +38,7 @@ ebuild.
 
 <note>
 The so-called <e>old-style</e> or <c>PROVIDE</c> type virtuals have been banned
-from the Portage tree.
+from the Gentoo repository.
 </note>
 </body>
 

--- a/profiles/categories/text.xml
+++ b/profiles/categories/text.xml
@@ -6,7 +6,7 @@
 <body>
 <p>
 The <c>profiles/categories</c> file contains an asciibetically sorted list of all
-the valid categories in the portage tree. When adding a new category, remember
+the valid categories in the Gentoo repository. When adding a new category, remember
 to update and commit this file <e>before</e> making any related commits.
 </p>
 

--- a/quickstart/text.xml
+++ b/quickstart/text.xml
@@ -309,7 +309,7 @@ src_install() {
 <p>
 Note the <c>${FILESDIR}/${P}-destdir.patch</c> <d/> this refers to
 <c>detox-1.1.0-destdir.patch</c>, which lives in the <c>files/</c>
-subdirectory in the Portage tree. Larger patch files must go on your
+subdirectory in the Gentoo repository. Larger patch files must go on your
 developer's space at <c>dev.gentoo.org</c> rather than in <c>files/</c> or
 mirrors <d/> see <uri link="::general-concepts/mirrors#Gentoo Mirrors"/> and <uri
 link="::ebuild-writing/functions/src_prepare/epatch/"/>.


### PR DESCRIPTION
The (previously referred) Portage Tree as been recently re-defined as the Gentoo repository.
for don't make confusion with the Portage package manager.
Changed Portage Tree with Gentoo Repository.

Gentoo-Bug: https://bugs.gentoo.org/show_bug.cgi?id=594258