### PR TITLE
ebuild-writing/variables: add HTML_DOCS, #591476

### DIFF
--- a/ebuild-writing/functions/src_install/text.xml
+++ b/ebuild-writing/functions/src_install/text.xml
@@ -63,6 +63,17 @@ src_install() {
 	fi
 }
 </codesample>
+<p>
+For EAPIs 6 and later, the default <c>src_install</c> function is the following:
+</p>
+<codesample lang="ebuild">
+src_install() {
+    if [[ -f Makefile ]] || [[ -f GNUmakefile ]] || [[ -f makefile ]] ; then
+        emake DESTDIR="${D}" install
+    fi
+    einstalldocs
+}
+</codesample>
 <important>The following examples assume EAPI 4 or later</important>
 </body>
 </section>

--- a/ebuild-writing/variables/text.xml
+++ b/ebuild-writing/variables/text.xml
@@ -280,9 +280,8 @@ The following variables may or must be defined by every ebuild.
     <ti><c>HTML_DOCS</c></ti>
     <ti>
     An array or space-delimited list of documentation files for
-    the default src_install function to install using dodoc into
-    the <c>html/</c> subdirectory of docdir (Requires
-    <uri link="::ebuild-writing/eapi/#eapi=6">EAPI>=6</uri>.)
+    the <c>einstalldocs</c> function to install using dodoc -r. 
+    (Requires <uri link="::ebuild-writing/eapi/#eapi=6">EAPI>=6</uri>.)
     </ti>
   </tr>
 </table>

--- a/ebuild-writing/variables/text.xml
+++ b/ebuild-writing/variables/text.xml
@@ -276,6 +276,15 @@ The following variables may or must be defined by every ebuild.
     <uri link="::ebuild-writing/eapi/#eapi=4">EAPI>=4</uri>.)
     </ti>
   </tr>
+  <tr>
+    <ti><c>HTML_DOCS</c></ti>
+    <ti>
+    An array or space-delimited list of documentation files for
+    the default src_install function to install using dodoc into
+    the <c>html/</c> subdirectory of docdir (Requires
+    <uri link="::ebuild-writing/eapi/#eapi=6">EAPI>=6</uri>.)
+    </ti>
+  </tr>
 </table>
 
 </body>

--- a/function-reference/install-functions/text.xml
+++ b/function-reference/install-functions/text.xml
@@ -130,6 +130,16 @@ the first is the source name, the second the name to use when installing.
   </tr>
   <tr>
     <ti>
+      <c>einstalldocs</c>
+    </ti>
+    <ti>
+      Installs the files specified by the <c>DOCS</c> and <c>HTML_DOCS</c>
+      variables into <c>/usr/share/doc/${PF}</c>. <b>Note</b>: Approved in
+      EAPI 6.
+    </ti>
+  </tr>
+  <tr>
+    <ti>
       <c>doenvd</c>
     </ti>
     <ti>


### PR DESCRIPTION
Gentoo-Bug: https://bugs.gentoo.org/show_bug.cgi?id=591476

adding a description for HTML_DOCS below the existing DOCS description