### PR TITLE
Shorten the text to facts.

### DIFF
--- a/ebuild-writing/common-mistakes/text.xml
+++ b/ebuild-writing/common-mistakes/text.xml
@@ -148,9 +148,8 @@ Removing "-Werror" from configure.ac can cause breakage in very rare cases where
 <body>
 
 <p>
-When you submit your ebuilds, the header should be <e>exactly</e> the same as
-the one in <path>/usr/portage/skel.ebuild</path>. Most importantly, do not
-modify it in any way and make sure that the <c>&#36;Id&#36;</c> line is intact.
+When you submit your ebuilds, the header must be <e>exactly</e> the same as
+the one in <path>/usr/portage/skel.ebuild</path>.
 </p>
 
 <p>
@@ -191,12 +190,12 @@ bug about that ebuild.
 </body>
 </subsection>
 <subsection>
-<title>Including version numbers in SRC_URI and S</title>
+<title>Including literal version numbers in SRC_URI and S</title>
 <body>
 
 <p>
-You should try not to include version numbers in the SRC_URI and S. Always try
-to use ${PV} or ${P}. It makes maintaining the ebuild much easier. If a version
+You should try not to include literal version numbers in the SRC_URI and S. Always try
+to use variables ${PV} or ${P}. It makes maintaining the ebuild much easier. If a version
 number is not consistent with the tarball/source, then use MY_P. An example
 dev-python/pyopenal fetches a tarball called PyOpenAL, so we redefine it like:
 </p>
@@ -302,7 +301,7 @@ uses <c>GPL-1</c> or <c>GPL-2</c>, it is very likely it uses <c>GPL-2</c>.
 </p>
 
 <p>
-If the license for the package you submit is unique and not in
+If the license for the package you submit is not yet in 
 <path>/usr/portage/licenses/</path>, then you must submit the new license in a
 separate file.
 </p>
@@ -327,8 +326,7 @@ Make sure when you bump a version, the stable KEYWORDS are all marked as
 <body>
 
 <p>
-Make sure you have the SLOT variable in the ebuild. If you don't plan to use it,
-don't remove it. Put in:
+Make sure you have the SLOT variable in the ebuild, even if you do not use it. Put in:
 </p>
 
 <pre caption="Default SLOT variable">
@@ -338,16 +336,17 @@ SLOT="0"
 </body>
 </subsection>
 <subsection>
-<title>DESCRIPTION and HOMEPAGE wrong</title>
+<title>Ambiguous DESCRIPTION or wrong HOMEPAGE</title>
 <body>
 
 <p>
-Please check if the HOMEPAGE variable is right and leads users to the right
-page if they want to find out more about the package. And make sure the
-DESCRIPTION is not overly long. Good descriptions will describe the main
-function of the package in a sentence.
+Make sure the factual DESCRIPTION describes the main function of the package in a short sentence.
+Please check if the HOMEPAGE variable leads users to the project website.
 </p>
-
+<pre caption="Set HOMEPAGE to No_homepage, if there is none">
+HOMEPAGE="https://wiki.gentoo.org/wiki/No_homepage"
+</pre>
+  
 </body>
 </subsection>
 <subsection>
@@ -366,7 +365,7 @@ the guidelines to use TABS rather than spaces. So <e>please</e> use tabs!
 <body>
 
 <p>
-I'm often guilty of this. Remember to run repoman over your ebuilds so it can
+Remember to run repoman over your ebuilds so it can
 tell you if there is trailing whitespace at the end of lines or on empty lines.
 </p>
 
@@ -457,7 +456,7 @@ Don't cut and paste an ebuild into bugzilla's comment field.
 </body>
 </subsection>
 <subsection>
-<title>No description on what the package is</title>
+<title>Unclear description on what the package is</title>
 <body>
 
 <p>


### PR DESCRIPTION
* today it is rather a common problem, that DESCRIPTION is ambiguous. No DESCRIPTION is not so common (anymore)
* add link to https://wiki.gentoo.org/wiki/No_homepage (perhaps make it a link later, or leave it as text for easier copy and paste)
* shorten here and there to facts