### PR TITLE
Improve documentation on revisions and revision bumps

### DIFF
--- a/general-concepts/ebuild-revisions/text.xml
+++ b/general-concepts/ebuild-revisions/text.xml
@@ -62,13 +62,50 @@ of thumb could be used as a guideline:
   </li>
 </ol>
 
-<p>
-Simple compile fixes do <b>not</b> warrant a revision bump; this is because they do
-not affect the installed package for users who already managed to compile it.
-Small documentation fixes are also usually not grounds for a new revision.
-In particular, this applies if the package has a substantial compilation
-time; developers should use their best judgement in these circumstances.
-</p>
+<p>Examples of changes that warrant a new revision are:</p>
+<ul>
+  <li>adding a patch to fix a runtime issue,</li>
+  <li>installing additional files that could be useful to the user,</li>
+  <li>adding a missing runtime dependency to one of the existing blocks,</li>
+  <li>
+    adding a missing build-time dependency that contributed to
+    a successfully yet incorrect build (e.g. missing some feature),
+  </li>
+  <li>
+    restricting a runtime dependency version, unless the <c>:=</c>
+    subslot operator is going to trigger a rebuild.
+  </li>
+</ul>
+
+<p>Examples of changes that can be done without a revision bump are:</p>
+<ul>
+  <li>
+    adding a patch to fix a build-time issue that prevented users from
+    building the package (since it does not affect users who already
+    managed to build it),
+  </li>
+  <li>adding a trivial documentation fix,</li>
+  <li>
+    installing an additional file of relatively little value (minor
+    documentation, editor syntax file, bash completion) compared
+    to the cost of rebuilding the package (especially if a new bump
+    is expected soon),
+  </li>
+  <li>
+    adding a missing build-time dependency that caused a build failure,
+  </li>
+  <li>
+    adding a new USE flag or removing an existing one (since change
+    in USE flags is going to trigger <c>--changed-use</c> rebuild),
+  </li>
+  <li>
+    a trivial stylistic / ebuild code change (as long as the new code
+    is equivalent to the old code),
+  </li>
+  <li>
+    a dependency change that is a result of a package move (slot move).
+  </li>
+</ul>
 
 </body>
 </chapter>

--- a/general-concepts/ebuild-revisions/text.xml
+++ b/general-concepts/ebuild-revisions/text.xml
@@ -8,8 +8,9 @@
 Ebuilds may have a Gentoo revision number associated with them. This is a
 <c>-rX</c> suffix, where <c>X</c> is an integer <d/> see <uri
 link="::ebuild-writing/file-format#File Naming Rules"/>. This
-component must only be used for Gentoo changes, not upstream releases. By
-default, <c>-r0</c> is implied.
+component must only be used for Gentoo changes, not upstream releases.
+An ebuild with no explicit revision number has the implicit <c>-r0</c>
+revision.
 </p>
 
 <p>

--- a/general-concepts/ebuild-revisions/text.xml
+++ b/general-concepts/ebuild-revisions/text.xml
@@ -28,13 +28,39 @@ revision.
 </ol>
 
 <p>
-Ebuilds should have their <c>-rX</c> incremented whenever a change is made which
-will make a substantial difference to what gets installed by the package <d/> by
-substantial, we generally mean "something for which many users would want to
-upgrade". This is usually for bugfixes.
-For any such revision bump, the new ebuild should be based on the
-previous revision to ensure that fixes aren't dropped accidentally.
+Developers are encouraged to use common sense when determining
+whether to introduce a new <c>-rX</c> revision. The following rule
+of thumb could be used as a guideline:
 </p>
+<ol>
+  <li>
+    If the change can cause the package to be broken to the point
+    of requiring users to revert to the previous version (in the case
+    of packages marked stable, every non-trivial change is classified
+    as such), then a new revision should be introduced and the old one
+    kept. If the package has stable keywords, the new revision should
+    be dropped to <c>~arch</c> (see
+    <uri link="::keywording#Keywording on Upgrades"/>).
+    For any such revision bump, the new ebuild should be based
+    on the previous revision to ensure that fixes aren't dropped
+    accidentally.
+  </li>
+
+  <li>
+    If the change makes a substantial difference to the user who already
+    installed the package (fixes runtime issues, changes installed files,
+    etc.) and it would not be propagated using other means, then
+    the ebuild should be renamed to a new revision. If the package has
+    stable keywords, they should be moved to the new revision without
+    dropping. To commit the ebuild, <c>repoman commit
+    --straight-to-stable</c> option should be used.
+  </li>
+
+  <li>
+    Otherwise, the change can be done in place in the current revision
+    of the ebuild.
+  </li>
+</ol>
 
 <p>
 Simple compile fixes do <b>not</b> warrant a revision bump; this is because they do
@@ -42,17 +68,6 @@ not affect the installed package for users who already managed to compile it.
 Small documentation fixes are also usually not grounds for a new revision.
 In particular, this applies if the package has a substantial compilation
 time; developers should use their best judgement in these circumstances.
-</p>
-
-<important>
-For ebuilds marked stable on at least one arch, only trivial edits can be made
-without a bump (e.g. typo fixes in elog messages). Even simple changes may
-result in a breakage. <b>Modifying stable ebuilds should be avoided.</b>
-</important>
-
-<p>
-When doing a revision bump, the usual rules about dropping to <c>~arch</c> apply.
-See <uri link="::keywording#Keywording on Upgrades"/>.
 </p>
 
 </body>

--- a/general-concepts/ebuild-revisions/text.xml
+++ b/general-concepts/ebuild-revisions/text.xml
@@ -13,6 +13,20 @@ An ebuild with no explicit revision number has the implicit <c>-r0</c>
 revision.
 </p>
 
+<p>Ebuild revisions usually serve two purposes:</p>
+<ol>
+  <li>
+    keeping an older copy of an ebuild around when doing a potentially
+    breaking change, and
+  </li>
+
+  <li>
+    propagating the rebuild of a package when performing a meaningful
+    change that would otherwise go unnoticed by users who have installed
+    the current version already.
+  </li>
+</ol>
+
 <p>
 Ebuilds should have their <c>-rX</c> incremented whenever a change is made which
 will make a substantial difference to what gets installed by the package <d/> by


### PR DESCRIPTION
Here's a refurbished version of the doc to help people figure out better to revbump or not to revbump.

The doc ended up a bit list-ish but I think it's going to improve the readability in the long run. The structure is pretty much:
1. what revision is and what is its purpose,
2. rule of thumb when to revbump,
3. example of when to revbump or not.

If you can think of more examples, I think it'd be useful to add them. The thing is always a little tricky for everyone, so the more samples, the less likely someone will do things wrong ;-).