### PR TITLE
ebuild-maintenance: Remove unagreed mentions of Gentoo-Bug

### DIFF
--- a/ebuild-maintenance/text.xml
+++ b/ebuild-maintenance/text.xml
@@ -160,25 +160,12 @@ people who are involved in authoring, suggesting, reviewing and
 testing the changes, and revelant bugs. Use RFC822/git style tags as
 explained in the
 <uri link="https://kernel.org/doc/html/latest/process/submitting-patches.html">
-Linux Kernel patch guideline</uri>. Additionally, the following tags
-are used in Gentoo:
+Linux Kernel patch guideline</uri>.
+</p>
 
-<ul>
-<li><c>Gentoo-Bug:</c> Use this to reference bugs in Gentoo Bugzilla
-by either the bug ID or the bugzilla URI. Multiple bugs can be
-referenced by inserting more tags of this type or separating bug IDs
-with a comma in the same tag. The bug IDs may include an optional '#'
-prefix. There is no consensus on referencing bugs in the summary line
-versus referencing with a tag in the message body. The developer has
-the option to choose either.
-</li>
-<li><c>Package-Manager:</c> This is automatically inserted by
-<c>repoman commit</c> and it specifies the version of
-<pkg>sys-apps/portage</pkg> on the system.</li>
-<li><c>RepoMan-Options:</c> This is automatically inserted by
-<c>repoman commit</c> and records the options passed to repoman (such
-as --force) for the commit.</li>
-</ul>
+<p>
+There is no consensus on how bugs should be referenced in the commit
+messages. Developers are free to use whatever form they prefer.
 </p>
 
 <p>
@@ -200,8 +187,6 @@ app-misc/foo: version bump to 0.5
 
 This also adds a new USE flag 'bar' which controls the
 new bar functionality introduced with this version.
-
-Gentoo-Bug: 01234
 </pre>
 
 </body>


### PR DESCRIPTION
Given that there is no consensus to use Gentoo-Bug in the commit
messages, I find it entirely inappropriate for the devmanual maintainers
to unilaterally push their preferred variant forward. Instead, remove
all the notions and explain the fact that there is no agreement.

While at it, remove the mention of Package-Manager and RepoMan-Options
footers. Users are not supposed to use those footer tags directly,
and their contents are implementation-defined.