### PR TITLE
Remove einstall reference and add Autotools Mythbuster

### DIFF
--- a/general-concepts/autotools/text.xml
+++ b/general-concepts/autotools/text.xml
@@ -675,6 +675,9 @@ For more details on autotools:
     <li>
       <uri link="https://www.gnu.org/software/m4/manual/m4.html">GNU m4 Manual</uri>
     </li>
+    <li>
+      <uri link="https://www.makefile.am/">Autotools Mythbuster</uri>
+    </li>
   </ul>
   <li>
     There are some good overview lectures available online. <uri

--- a/quickstart/text.xml
+++ b/quickstart/text.xml
@@ -153,8 +153,7 @@ this <d/> see <uri link="::general-concepts/install-destinations"/> and
 <note>
 The canonical install method is <c>emake DESTDIR=&quot;${D}&quot;
 install</c>. This will work with any properly written standard
-<c>Makefile</c>. If this gives sandbox errors, try <c>einstall</c>
-instead. If this still fails, see <uri
+<c>Makefile</c>. If this gives sandbox errors, see <uri
 link="::ebuild-writing/functions/src_install/"/> for how to do manual
 installs.
 </note>


### PR DESCRIPTION
It is banned since EAPI=6, older EAPIs are deprecated. Also one more reference for autotools