### PR TITLE
ebuild-writing: Stop encouraging empty USE_EXPAND hack

### DIFF
--- a/ebuild-writing/variables/text.xml
+++ b/ebuild-writing/variables/text.xml
@@ -370,23 +370,6 @@ SRC_URI="https://example.com/files/${P}-core.tar.bz2
 	doc?   ( https://example.com/files/${P}/${P}-docs.tar.bz2 )"
 </codesample>
 
-<p>
-If a <c>USE_EXPAND</c> variable is used to control whether certain optional
-components are installed, the correct thing to do if the variable is unset is
-generally to install <e>all</e> available components.
-</p>
-
-<codesample lang="ebuild">
-SRC_URI="https://example.com/files/${P}-core.tar.bz2
-	examplecards_foo?  ( https://example.com/files/${P}-foo.tar.bz2 )
-	examplecards_bar?  ( https://example.com/files/${P}-bar.tar.bz2 )
-	examplecards_baz?  ( https://example.com/files/${P}-baz.tar.bz2 )
-	!examplecards_foo? ( !examplecards_bar? ( !examplecards_baz? (
-		https://example.com/files/${P}-foo.tar.bz2
-		https://example.com/files/${P}-bar.tar.bz2
-		https://example.com/files/${P}-baz.tar.bz2 ) ) )"
-</codesample>
-
 </body>
 </subsection>
 


### PR DESCRIPTION
Remove the suggestion that 'no flags = all options'.  We certainly
aren't doing it these days, and the problem is better resolved with
defaulting USE_EXPAND and/or REQUIRED_USE these days.