### PR TITLE
Update code snippets in quickstart, and copyright headers

### DIFF
--- a/ebuild-writing/common-mistakes/text.xml
+++ b/ebuild-writing/common-mistakes/text.xml
@@ -163,7 +163,7 @@ The first two lines <e>must</e> look like this:
 </p>
 
 <pre caption="Valid Header">
-# Copyright 1999-2019 Gentoo Foundation
+# Copyright 1999-2019 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 </pre>
 

--- a/ebuild-writing/eapi/text.xml
+++ b/ebuild-writing/eapi/text.xml
@@ -42,7 +42,7 @@ Most developers prefer to set the EAPI version without quotes. However, the PMS 
 </note>
 
 <codesample lang="ebuild">
-# Copyright 1999-2019 Gentoo Foundation
+# Copyright 1999-2019 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -117,7 +117,7 @@ src_compile() {
 		</important>
 
 		<codesample lang="ebuild">
-# Copyright 1999-2019 Gentoo Foundation
+# Copyright 1999-2019 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=1
@@ -523,7 +523,7 @@ DEPEND="
 		</p>
 		<p>Example:</p>
 		<codesample lang="ebuild">
-# Copyright 1999-2019 Gentoo Foundation
+# Copyright 1999-2019 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=4

--- a/ebuild-writing/file-format/text.xml
+++ b/ebuild-writing/file-format/text.xml
@@ -151,7 +151,7 @@ header.txt</uri></c> in the top directory of the Gentoo repository.
 </p>
 
 <codesample lang="ebuild">
-# Copyright 1999-2019 Gentoo Foundation
+# Copyright 1999-2019 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 </codesample>
 

--- a/ebuild-writing/functions/src_unpack/rpm-sources/text.xml
+++ b/ebuild-writing/functions/src_unpack/rpm-sources/text.xml
@@ -52,7 +52,7 @@ patches. The filename should be <c>suse-fetchmail-6.2.5.54.1.ebuild</c>.
 </p>
 
 <codesample lang="ebuild">
-# Copyright 1999-2019 Gentoo Foundation
+# Copyright 1999-2019 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI="6"

--- a/ebuild-writing/using-eclasses/text.xml
+++ b/ebuild-writing/using-eclasses/text.xml
@@ -32,7 +32,7 @@ uses three eclasses:
 </p>
 
 <codesample lang="ebuild">
-# Copyright 1999-2019 Gentoo Foundation
+# Copyright 1999-2019 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=7

--- a/eclass-writing/text.xml
+++ b/eclass-writing/text.xml
@@ -612,7 +612,7 @@ a single function, <c>domacosapp</c>.
 </p>
 
 <codesample lang="ebuild">
-# Copyright 1999-2019 Gentoo Foundation
+# Copyright 1999-2019 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 # @ECLASS: macosapp.eclass
@@ -699,7 +699,7 @@ something like the following:
 </p>
 
 <codesample lang="ebuild">
-# Copyright 1999-2019 Gentoo Foundation
+# Copyright 1999-2019 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 # @ECLASS: jmake.eclass
@@ -760,7 +760,7 @@ for an eclass to invoke die from the global scope.  For example:
 </p>
 
 <codesample lang="ebuild">
-# Copyright 1999-2019 Gentoo Foundation
+# Copyright 1999-2019 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 # @ECLASS: eapi-die.eclass

--- a/quickstart/text.xml
+++ b/quickstart/text.xml
@@ -225,11 +225,6 @@ DEPEND="${RDEPEND}
 src_configure() {
 	econf --with-popt
 }
-
-src_install() {
-	emake DESTDIR="${D}" install
-	dodoc README CHANGES
-}
 </codesample>
 
 <p>
@@ -241,7 +236,9 @@ variables <d/> see
 </p>
 
 <p>
-Again, we define <c>src_configure</c> and <c>src_install</c> functions.
+We define <c>src_configure</c> only.  <c>src_install</c> does not need to
+be defined since the default implementation calling <c>emake install</c>
+and installing common documentation files works correctly for the package.
 </p>
 
 <p>
@@ -291,11 +288,6 @@ src_prepare() {
 src_configure() {
 	econf --with-popt
 }
-
-src_install() {
-	emake DESTDIR="${D}" install
-	dodoc README CHANGES
-}
 </codesample>
 
 <p>
@@ -338,10 +330,6 @@ DEPEND="!sys-libs/glibc"
 
 src_configure() {
 	econf $(use_enable nls)
-}
-
-src_install() {
-	emake DESTDIR="${D}" install
 }
 </codesample>
 

--- a/quickstart/text.xml
+++ b/quickstart/text.xml
@@ -260,20 +260,15 @@ compile-time dependencies, and the <c>RDEPEND</c> lists runtime dependencies. Se
 <body>
 <p>
 Often we need to apply patches. This is done in the <c>src_prepare</c>
-function using the <c>epatch</c> helper function. To use <c>epatch</c>
-one must first tell Portage that the <c>epatch</c> eclass (an eclass is
-like a library) is required <d/>
-this is done via <c>inherit epatch</c> at the top of the ebuild. Here's
-<c>app-misc/detox/detox-1.1.0.ebuild</c>:
+function using the <c>eapply</c> helper function. To use <c>eapply</c>
+one must use EAPI 7. Here's <c>app-misc/detox/detox-1.1.0.ebuild</c>:
 </p>
 
 <codesample lang="ebuild">
 # Copyright 1999-2019 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=5
-
-inherit epatch
+EAPI=7
 
 DESCRIPTION="detox safely removes spaces and strange characters from filenames"
 HOMEPAGE="http://detox.sourceforge.net/"
@@ -289,7 +284,7 @@ DEPEND="${RDEPEND}
 	sys-devel/bison"
 
 src_prepare() {
-	epatch "${FILESDIR}"/${P}-destdir.patch \
+	eapply "${FILESDIR}"/${P}-destdir.patch \
 		"${FILESDIR}"/${P}-parallel_build.patch
 }
 
@@ -371,9 +366,9 @@ Another more complicated example, this time based upon
 # Copyright 1999-2019 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
-EAPI=5
+EAPI=7
 
-inherit epatch desktop
+inherit desktop
 
 DESCRIPTION="A lightweight email client and newsreader"
 HOMEPAGE="https://sylpheed.good-day.net/"
@@ -398,7 +393,7 @@ DEPEND="${RDEPEND}
 	nls? ( >=sys-devel/gettext-0.12.1 )"
 
 src_prepare() {
-	epatch "${FILESDIR}"/${PN}-namespace.diff \
+	eapply "${FILESDIR}"/${PN}-namespace.diff \
 		"${FILESDIR}"/${PN}-procmime.diff
 }
 

--- a/quickstart/text.xml
+++ b/quickstart/text.xml
@@ -398,15 +398,18 @@ src_prepare() {
 }
 
 src_configure() {
-	econf \
-		$(use_enable nls) \
-		$(use_enable ssl) \
-		$(use_enable crypt gpgme) \
-		$(use_enable pda jpilot) \
-		$(use_enable ldap) \
-		$(use_enable ipv6) \
-		$(use_enable imlib) \
+	local myconf=(
+		$(use_enable nls)
+		$(use_enable ssl)
+		$(use_enable crypt gpgme)
+		$(use_enable pda jpilot)
+		$(use_enable ldap)
+		$(use_enable ipv6)
+		$(use_enable imlib)
 		$(use_enable xface compface)
+	)
+
+	econf "${myconf[@]}"
 }
 
 src_install() {

--- a/quickstart/text.xml
+++ b/quickstart/text.xml
@@ -43,7 +43,7 @@ DESCRIPTION="Exuberant ctags generates tags files for quick source navigation"
 HOMEPAGE="http://ctags.sourceforge.net"
 SRC_URI="mirror://sourceforge/ctags/${P}.tar.gz"
 
-LICENSE="GPL-2"
+LICENSE="GPL-2+"
 SLOT="0"
 KEYWORDS="~mips ~sparc ~x86"
 
@@ -111,7 +111,8 @@ name and version <d/> in this case, it would be <c>ctags-5.5.4</c>.
 </p>
 
 <p>
-The <c>LICENSE</c> is <c>GPL-2</c> (the GNU General Public License version 2).
+The <c>LICENSE</c> is <c>GPL-2+</c> (the GNU General Public License version 2
+or (at your option) any later version).
 </p>
 
 <p>
@@ -333,7 +334,7 @@ DESCRIPTION="GNU charset conversion library for libc which doesn't implement it"
 HOMEPAGE="https://www.gnu.org/software/libiconv/"
 SRC_URI="ftp://ftp.gnu.org/pub/gnu/libiconv/${P}.tar.gz"
 
-LICENSE="LGPL-2.1"
+LICENSE="LGPL-2+ GPL-3+"
 SLOT="0"
 KEYWORDS="~amd64 ~ppc ~sparc ~x86"
 IUSE="nls"
@@ -378,7 +379,7 @@ DESCRIPTION="A lightweight email client and newsreader"
 HOMEPAGE="https://sylpheed.good-day.net/"
 SRC_URI="mirror://sourceforge/${PN}/${P}.tar.bz2"
 
-LICENSE="GPL-2"
+LICENSE="GPL-2+ LGPL-2.1+"
 SLOT="0"
 KEYWORDS="alpha amd64 hppa ia64 ppc ppc64 sparc x86"
 IUSE="crypt imlib ipv6 ldap nls pda ssl xface"

--- a/quickstart/text.xml
+++ b/quickstart/text.xml
@@ -34,7 +34,7 @@ can see real ebuilds in the main tree).
 </p>
 
 <codesample lang="ebuild">
-# Copyright 1999-2019 Gentoo Foundation
+# Copyright 1999-2019 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=6
@@ -203,7 +203,7 @@ Here's <c>app-misc/detox/detox-1.1.1.ebuild</c>:
 </p>
 
 <codesample lang="ebuild">
-# Copyright 1999-2019 Gentoo Foundation
+# Copyright 1999-2019 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
@@ -267,7 +267,7 @@ this is done via <c>inherit epatch</c> at the top of the ebuild. Here's
 </p>
 
 <codesample lang="ebuild">
-# Copyright 1999-2019 Gentoo Foundation
+# Copyright 1999-2019 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
@@ -324,7 +324,7 @@ replacement iconv for <c>libc</c> implementations which don't have their own.
 </p>
 
 <codesample lang="ebuild">
-# Copyright 1999-2019 Gentoo Foundation
+# Copyright 1999-2019 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
@@ -367,7 +367,7 @@ Another more complicated example, this time based upon
 </p>
 
 <codesample lang="ebuild">
-# Copyright 1999-2019 Gentoo Foundation
+# Copyright 1999-2019 Gentoo Authors
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5


### PR DESCRIPTION
1. Update copyright header to state 'Gentoo Authors' everywhere.
2. Update the code snippets in quickstart to be more modern:
   * use eapply instead of epatch
   * avoid redefining default src_install whenever it would just work
   * prefer `myconf` array over backslash hell for large number of flags
3. Correct licenses