### PR TITLE
general-concepts/use-flags: remove redundant 'die' from the example

### DIFF
--- a/general-concepts/use-flags/text.xml
+++ b/general-concepts/use-flags/text.xml
@@ -283,7 +283,7 @@ src_compile() {
 		# Other stuff
 		${myconf}
 
-	emake || die "make failed"
+	emake
 }
 </codesample>
 


### PR DESCRIPTION
Signed-off-by: Stefan Strogin <steils@gentoo.org>