### PR TITLE
eclass-writing: Word review requirement more strongly

### DIFF
--- a/eclass-writing/text.xml
+++ b/eclass-writing/text.xml
@@ -67,10 +67,8 @@ package, and thus does not typically require changes to be emailed for review.
 </p>
 
 <p>
-When removing a function or changing the API of an eclass, make
-sure that it doesn't break any ebuilds in the tree, and post a
-notice to gentoo-dev at least 30 days in advance, preferably with
-a patch included.
+When removing a function or changing the API of an eclass, make sure that
+it doesn't break any ebuilds in the Gentoo repository.
 </p>
 
 <p>

--- a/eclass-writing/text.xml
+++ b/eclass-writing/text.xml
@@ -53,12 +53,17 @@ does not require a new eclass will be suggested.
 </p>
 
 <p>
-Before updating <c>eutils</c> or a similar widely used eclass, it is best to email
-the gentoo-dev list. It may be that your proposed change is broken in a way you
-had not anticipated, or that there is an existing function which performs the
-same purpose, or that your function may be better off in its own eclass. If you
-don't email gentoo-dev first, and end up breaking something, expect to be in a
-lot of trouble.
+Before updating any eclass, email patches to the gentoo-dev list. It may be that
+your proposed change is broken in a way you had not anticipated, or that there
+is an existing function which performs the same purpose, or that your function
+may be better off in its own eclass. If you don't email gentoo-dev first,
+and end up breaking something, expect to be in a lot of trouble.
+</p>
+
+<p>
+The exceptions to this rule are per-package eclasses. For example,
+the <c>apache-2</c> eclass is only used by the <c>www-servers/apache</c>
+package, and thus does not typically require changes to be emailed for review.
 </p>
 
 <p>
@@ -71,11 +76,6 @@ a patch included.
 <p>
 If there is an existing maintainer for an eclass (this is usually the case), you
 <b>must</b> talk to the maintainer before committing any changes.
-</p>
-
-<p>
-It is not usually necessary to email the gentoo-dev list before making changes
-to a non-general eclass which you maintain. Use common sense here.
 </p>
 
 <warning>


### PR DESCRIPTION
Make the review of eclass updates an explicit requirement rather than
strong suggestion.  To make it more clear, replace blurry 'widely used
eclass' with 'eclass used by packages that you do not maintain'.  This
should also match the motivation better, as other package maintainers
certainly want to know about changes to the eclasses they're using.

This paragraph is already followed by paragraphs making the review
obligatory for API changes.  Having a single policy (requiring review
rather than first suggesting it, then requiring in special cases) should
also avoid misunderstandings.

Also provide an example for the kind of eclasses that do not require
public review.