### PR TITLE
gen-eclass-html: Filter eclass-manpages installed file list

### DIFF
--- a/bin/gen-eclass-html.sh
+++ b/bin/gen-eclass-html.sh
@@ -36,7 +36,7 @@ IFS='' read -r -d '' FOOTER << 'EOF'
 EOF
 
 # We also need the ebuild man page
-for i in $(/usr/bin/qlist eclass-manpages) /usr/share/man/man5/ebuild.5.bz2; do
+for i in $(/usr/bin/qlist eclass-manpages | grep man5) /usr/share/man/man5/ebuild.5.bz2; do
 	BASENAME="$(basename $i .5.bz2)"
 	DIRNAME="${OUTPUTDIR}/${BASENAME}"
 	TMP="${DIRNAME}/index.html.tmp"


### PR DESCRIPTION
Filter installed file list to manpages only, as eclass-manpages now
installs the script as well.  Fixes the cronjob error:

    bunzip2: /usr/bin/eclass-to-manpage.awk is not a bzip2 file.

Signed-off-by: Michał Górny <mgorny@gentoo.org>