### PR TITLE
Elaborate on package maintainers, kill old herds section

### DIFF
--- a/ebuild-maintenance/maintenance-tasks/text.xml
+++ b/ebuild-maintenance/maintenance-tasks/text.xml
@@ -137,39 +137,6 @@ which is often more convenient.
 </section>
 
 <section>
-<title>Touching other developers ebuilds</title>
-<body>
-<p>
-Usually you don't just change other developers ebuilds without
-permission unless you know that developer does not mind or if you are
-part of the project involved in maintenance (this information can
-typically be found in metadata.xml). Start with filing a bug or trying
-to catch them on IRC or via email. Sometimes you cannot reach them, or
-there is no response to your bug. It's a good idea to consult other
-developers on how to handle the situation, especially if it's a
-critical issue that needs to be handled ASAP. Otherwise a soft limit
-of 2 to 4 weeks depending on the severity of the bug is an acceptable
-time frame before you go ahead and fix it yourself.
-</p>
-<important>
-Common sense dictates to us that toolchain/base-system/core packages
-and eclasses or anything else which is delicate (e.g. glibc) or widely
-used (e.g. gtk+) should usually be left to those maintainers. If in
-doubt, don't touch it.
-</important>
-
-<p>
-Respect developers' coding preferences. Unnecessarily changing the
-syntax of an ebuild can cause complications for others. Syntax changes
-should only be done if there is a real benefit, such as faster
-compilation, improved information for the end user, or compliance with
-Gentoo policies.
-</p>
-
-</body>
-</section>
-
-<section>
 <title>Stabilizing ebuilds</title>
 <body>
 

--- a/ebuild-writing/misc-files/metadata/text.xml
+++ b/ebuild-writing/misc-files/metadata/text.xml
@@ -333,7 +333,7 @@ There are also some attributes that can be used with these tags:
     Defines the type of the maintainer for a package. There are only
     two valid values: <c>"person"</c> and <c>"project"</c>. The latter
     denotes an official
-    <uri link="::general-concepts/herds-and-projects">
+    <uri link="::general-concepts/projects">
     Gentoo project</uri>.
   </ti>
 </tr>

--- a/general-concepts/package-maintainers/text.xml
+++ b/general-concepts/package-maintainers/text.xml
@@ -1,0 +1,93 @@
+<?xml version="1.0"?>
+<guide self="general-concepts/package-maintainers/">
+<chapter>
+<title>Package Maintainers</title>
+<body>
+
+<p>
+Package maintainers are responsible for ebuild maintenance tasks <d/>
+bumping ebuilds to new upstream releases, updating them as necessary
+with regards to policies, replying to bugs, etc. The maintainers
+of a package are listed in the package's <uri
+link="::ebuild-writing/misc-files/metadata/">metadata.xml</uri> file.
+When assigning bugs, the first maintainer listed becomes the bug's
+assignee and the remaining maintainers are added to CC, unless stated
+otherwise in the metadata.
+</p>
+
+<section>
+<title>Maintainer authority</title>
+<body>
+
+<p>
+Package maintainers have authority over their maintained packages.
+Unless specified otherwise, you should request maintainers' approval
+before committing to their packages. Try filing a bug, catching them
+on IRC or sending a mail first. The exceptions to this rule are trivial
+changes implied by your own actions, e.g. dependency updates as a result
+of package moves.
+</p>
+
+<p>
+In case of maintainer inactivity, it is a good idea to consult other
+developers on how to handle the situation, especially if it is
+a critical issue that needs to be handled ASAP. A customary tool
+of maintainer timeout may be used in this case. This timeout can be
+invoked if none of the package's maintainers reply to a patch within
+2<d/>4 weeks of it being attached or linked to a correctly assigned bug,
+or being sent to the maintainer.
+</p>
+
+<important>
+Common sense dictates to us that toolchain/base-system/core packages
+and eclasses or anything else which is delicate (e.g. glibc) or widely
+used (e.g. GTK+) should usually be left to their maintainers.
+If in doubt, don't touch it.
+</important>
+
+<p>
+Respect developers' coding preferences. Unnecessarily changing
+the syntax of an ebuild can cause complications for others. Syntax
+changes should only be done if there is a real benefit, such as faster
+compilation, improved information for the end user, or compliance
+with Gentoo policies.
+</p>
+
+</body>
+</section>
+
+<section>
+<title>Adding and removing maintainers</title>
+<body>
+
+<p>
+All packages newly added to the Gentoo repository must have at least
+one maintainer specified. New maintainers can only be added with their
+consent. In particular, it is not acceptable to add generic projects
+(such as the Python project) as package maintainers without the approval
+of their members or against their explicit policy.
+</p>
+
+<p>
+Maintainers without commit access are called proxied maintainers. Their
+changes must be pushed by a Gentoo developer, who acts as their proxy.
+All packages maintained by proxied maintainers must explicitly list
+their proxy developer or project in <c>metadata.xml</c>.
+</p>
+
+<p>
+When adding new maintainers or removing old maintainers, please remember
+to reassign bugs. The last maintainer to resign from maintaining
+the package must place a <c>&lt;!-- maintainer-needed --&gt;</c> comment
+in <c>metadata.xml</c>, in order simplify finding unmaintained packages.
+It is also required to send an 'up for grabs' email to the
+<c>gentoo-dev-announce</c> and <c>gentoo-dev</c> mailing lists,
+providing a list of newly-unmaintained packages.
+</p>
+
+</body>
+</section>
+
+</body>
+</chapter>
+</guide>

--- a/general-concepts/projects/text.xml
+++ b/general-concepts/projects/text.xml
@@ -1,11 +1,6 @@
 <?xml version="1.0"?>
-<guide self="general-concepts/herds-and-projects/">
+<guide self="general-concepts/projects/">
 <chapter>
-<title>Projects and Herds</title>
-
-<body>
-
-<section>
 <title>Projects</title>
 <body>
 
@@ -33,7 +28,7 @@ api.gentoo.org</uri> or on the
 <uri link="https://wiki.gentoo.org/wiki/Project:Gentoo">wiki</uri>.
 </p>
 
-<subsection>
+<section>
 <title>Starting New Projects</title>
 <body>
 
@@ -61,8 +56,9 @@ project with the same goals.
 </p>
 
 </body>
-</subsection>
-<subsection>
+</section>
+
+<section>
 <title>Joining and Leaving a Project</title>
 <body>
 
@@ -85,47 +81,8 @@ the project's email address <c>devmanual@gentoo.org</c>.
 </p>
 
 </body>
-</subsection>
-
-</body>
-</section>
-
-<section>
-<title>Herds</title>
-<body>
-
-<warning>
-Herds have been declared obsolete as per the Gentoo Council's <uri
-link="https://projects.gentoo.org/council/meeting-logs/20160110-summary.txt">
-decision on January 10, 2016</uri>. The following section is preserved
-for historical purposes.
-</warning>
-
-<p>
-A <e>herd</e> is a collection of packages with an associated set of maintainers.
-It can happen for example because of retirement that a herd has no developers
-but this should be avoided if at all possible. A herd has an associated email
-address which can be used for bugzilla assignments. This email address is
-<b>not</b> always <c>herdname@gentoo.org</c> <d/> for example, because of the
-way Gentoo's email aliases are set up, the <c>cron</c> herd use
-<c>cron-bugs@gentoo.org</c> (aliases cannot match system usernames).
-</p>
-
-<p>
-A <e>project</e> is a group formed for handling a particular general area. A project
-may have herds associated with it.
-</p>
-
-<p>
-Sometimes herd and project names overlap <d/> for example, the <c>sparc</c> project
-has an associated <c>sparc</c> herd which maintains sparc-specific packages (such
-as the <c>silo</c> bootloader). This is <e>not</e> always the case.
-</p>
-
-</body>
 </section>
 
 </body>
 </chapter>
 </guide>
-

--- a/general-concepts/text.xml
+++ b/general-concepts/text.xml
@@ -33,6 +33,7 @@ writing ebuilds or working with the Gentoo repository.
 <include href="mirrors/"/>
 <include href="news/"/>
 <include href="overlay/"/>
+<include href="package-maintainers/"/>
 <include href="pic/"/>
 <include href="portage-cache/"/>
 <include href="projects/"/>

--- a/general-concepts/text.xml
+++ b/general-concepts/text.xml
@@ -28,7 +28,6 @@ writing ebuilds or working with the Gentoo repository.
 <include href="emerge-and-ebuild/"/>
 <include href="features/"/>
 <include href="filesystem/"/>
-<include href="herds-and-projects/"/>
 <include href="install-destinations/"/>
 <include href="licenses/"/>
 <include href="mirrors/"/>
@@ -36,6 +35,7 @@ writing ebuilds or working with the Gentoo repository.
 <include href="overlay/"/>
 <include href="pic/"/>
 <include href="portage-cache/"/>
+<include href="projects/"/>
 <include href="sandbox/"/>
 <include href="slotting/"/>
 <include href="tree/"/>


### PR DESCRIPTION
Reuse 'Herds and Projects' chapter as more generic 'Package Maintainers'. Remove obsolete section on herds, and elaborate in detail on maintainers.