### PR TITLE
general-concepts/dependencies: Fix ranged dependencies example

### DIFF
--- a/general-concepts/dependencies/text.xml
+++ b/general-concepts/dependencies/text.xml
@@ -195,7 +195,7 @@ the asterisk postfix. This is most commonly seen in situations like:
 </p>
 
 <codesample lang="ebuild">
-DEPEND="gtk? ( =x11-libs/gtk+-1.2* )"
+DEPEND="gtk? ( =x11-libs/gtk+-2* )"
 </codesample>
 
 <p>


### PR DESCRIPTION
The error should be obvious: Text is saying 

> To specify "version **2.x** (not 1.x or 3.x)" of a package

but the example would pin version to 1.2.x.