### PR TITLE
Updates to mirror-related information

### DIFF
--- a/ebuild-writing/variables/text.xml
+++ b/ebuild-writing/variables/text.xml
@@ -399,22 +399,25 @@ SRC_URI="https://example.com/files/${PV}.tar.gz -> ${P}.tar.gz"
 
 
 <subsection>
-  <title>Third-party mirrors</title>
-  <body>
-    <p>
-      If the items in <c>SRC_URI</c> are available on multiple
-      third-party mirrors, then you don't have to list each mirror in
-      your ebuild. The <c>profiles/thirdpartymirrors</c> file in the
-      <c>::gentoo</c> repository contains named groups of mirrors,
-      accessible through the <c>mirror://</c> pseudo-protocol.
-    </p>
-    <p>
-      As of EAPI 7, the format of <uri
-      link="https://projects.gentoo.org/pms/7/pms.html#x1-340004.4.2">the
-      thirdpartymirrors file</uri> is described in section 4.4.2 of
-      the Package Manager Specification (PMS). One might define a set
-      of &quot;example&quot; mirrors,
-    </p>
+<title>Third-party mirrors</title>
+<body>
+
+<p>
+If the items in <c>SRC_URI</c> are available on multiple third-party mirrors,
+then you don't have to list each mirror in your ebuild.
+The <c>profiles/thirdpartymirrors</c> file in the <c>::gentoo</c> repository
+contains named groups of mirrors, accessible through the <c>mirror://</c>
+pseudo-protocol.
+</p>
+
+<p>
+As of EAPI 7, the format of <uri
+link="https://projects.gentoo.org/pms/7/pms.html#x1-340004.4.2">the
+thirdpartymirrors file</uri> is described in section 4.4.2 of the Package
+Manager Specification (PMS). One might define a set of &quot;example&quot;
+mirrors,
+</p>
+
 <!--
   The following isn't ebuild code, but lang="ebuild" works, and no
   other language choice would be accurate either.
@@ -422,25 +425,26 @@ SRC_URI="https://example.com/files/${PV}.tar.gz -> ${P}.tar.gz"
 <codesample lang="ebuild">
 example https://download.example.com https://mirror1.example.org/example
 </codesample>
-    <p>
-      that can afterwards be referenced through a <c>mirror://</c>
-      URL:
-    </p>
+
+<p>
+that can afterwards be referenced through a <c>mirror://</c> URL:
+</p>
+
 <codesample lang="ebuild">
 SRC_URI="mirror://example/${PN}/${P}.tar.gz"
 </codesample>
-    <warning>
-      If the sources for a package are neither mirror-restricted nor
-      fetch-restricted, then they will be <uri
-      link="::general-concepts/mirrors">mirrored onto Gentoo
-      infrastructure</uri> automatically; in that case, there is
-      little benefit to using this feature. There is a maintenance
-      burden associated with using a third-party mirror list: it must
-      be updated when new mirrors are born and when old mirrors
-      die. Please consider that when deciding whether or not to use
-      this feature.
-    </warning>
-  </body>
+
+<warning>
+If the sources for a package are neither mirror-restricted nor
+fetch-restricted, then they will be <uri
+link="::general-concepts/mirrors">mirrored onto Gentoo infrastructure</uri>
+automatically; in that case, there is little benefit to using this feature.
+There is a maintenance burden associated with using a third-party mirror list:
+it must be updated when new mirrors are born and when old mirrors die. Please
+consider that when deciding whether or not to use this feature.
+</warning>
+
+</body>
 </subsection>
 </section>
 

--- a/ebuild-writing/variables/text.xml
+++ b/ebuild-writing/variables/text.xml
@@ -420,7 +420,7 @@ SRC_URI="https://example.com/files/${PV}.tar.gz -> ${P}.tar.gz"
   other language choice would be accurate either.
 -->
 <codesample lang="ebuild">
-example http://download.example.org/ ftp://ftp.example.org/
+example https://download.example.com https://mirror1.example.org/example
 </codesample>
     <p>
       that can afterwards be referenced through a <c>mirror://</c>

--- a/ebuild-writing/variables/text.xml
+++ b/ebuild-writing/variables/text.xml
@@ -435,15 +435,28 @@ that can afterwards be referenced through a <c>mirror://</c> URL:
 SRC_URI="mirror://example/${PN}/${P}.tar.gz"
 </codesample>
 
-<warning>
-If the sources for a package are neither mirror-restricted nor
-fetch-restricted, then they will be <uri
-link="::general-concepts/mirrors">mirrored onto Gentoo infrastructure</uri>
-automatically; in that case, there is little benefit to using this feature.
-There is a maintenance burden associated with using a third-party mirror list:
-it must be updated when new mirrors are born and when old mirrors die. Please
-consider that when deciding whether or not to use this feature.
-</warning>
+<p>
+There are two valid cases for using <c>thirdpartymirrors</c>:
+</p>
+
+<ol>
+  <li>
+    providing multiple download locations for mirror- or fetch-restricted
+    packages,
+  </li>
+
+  <li>
+    dealing with upstreams that distribute their distfiles via a network
+    of mirrors without a primary download location or a bouncer service.
+  </li>
+</ol>
+
+<p>
+In any other case, the primary location must be used instead. The distfiles
+will be <uri link="::general-concepts/mirrors">mirrored onto Gentoo
+infrastructure</uri>; in that case, the benefit to using third-party mirror
+list does not outweigh the burden of maintaining it.
+</p>
 
 </body>
 </subsection>

--- a/ebuild-writing/variables/text.xml
+++ b/ebuild-writing/variables/text.xml
@@ -404,7 +404,8 @@ SRC_URI="https://example.com/files/${PV}.tar.gz -> ${P}.tar.gz"
 
 <p>
 If the items in <c>SRC_URI</c> are available on multiple third-party mirrors,
-then you don't have to list each mirror in your ebuild.
+and the same set of mirrors is shared across multiple ebuilds, then you
+don't have to repeatedly list each of them in every ebuild.
 The <c>profiles/thirdpartymirrors</c> file in the <c>::gentoo</c> repository
 contains named groups of mirrors, accessible through the <c>mirror://</c>
 pseudo-protocol.

--- a/ebuild-writing/variables/text.xml
+++ b/ebuild-writing/variables/text.xml
@@ -407,7 +407,7 @@ If the items in <c>SRC_URI</c> are available on multiple third-party mirrors,
 and the same set of mirrors is shared across multiple ebuilds, then you
 don't have to repeatedly list each of them in every ebuild.
 The <c>profiles/thirdpartymirrors</c> file in the <c>::gentoo</c> repository
-contains named groups of mirrors, accessible through the <c>mirror://</c>
+contains named groups of mirrors, in the format specified by the Package Manager Specification (PMS), accessible through the <c>mirror://</c>
 pseudo-protocol.
 </p>
 
@@ -415,7 +415,7 @@ pseudo-protocol.
 As of EAPI 7, the format of <uri
 link="https://projects.gentoo.org/pms/7/pms.html#x1-340004.4.2">the
 thirdpartymirrors file</uri> is described in section 4.4.2 of the Package
-Manager Specification (PMS). One might define a set of &quot;example&quot;
+One might define a set of &quot;example&quot;
 mirrors,
 </p>
 

--- a/general-concepts/mirrors/text.xml
+++ b/general-concepts/mirrors/text.xml
@@ -50,16 +50,24 @@ found. This should only be used if a license requires it.
 <title>Replacing Automatically Mirrored Files</title>
 <body>
 <p>
-On rare occasions you may need to replace a file that is already mirrored.  In this case proceed as
-follows:
-<ol>
-  <li>Put a copy of the new distfile on dev.gentoo.org into /space/distfiles-local</li>
-  <li>commit the new manifest to the git tree</li>
-  <li>wait</li>
-</ol>
-After a few hours a cron job on dev.gentoo.org will fetch the file and replace the version on the
-mirrors.  The file will be automatically removed from /space/distfiles-local after approximately two
-weeks.
+On rare occasions you may need to replace a file that is already mirrored.
+This is usually the case when upstream remakes a release package. If this
+is necessary, please use <c>SRC_URI</c> arrow to rename the file. For example:
+</p>
+
+<codesample lang="ebuild">
+# upstream updated the distfile in place, so make it .r1
+SRC_URI="https://example.com/badupstream/${P}.tar.gz -> ${P}.r1.tar.gz"
+</codesample>
+
+<p>
+Since Gentoo mirrors operate using local distfile names, they will automatically
+fetch and start distributing the new version.
+</p>
+
+<p>
+Please note that if upstream made any changes affecting the built package,
+you need to also bump the ebuild's revision.
 </p>
 
 <p>

--- a/general-concepts/mirrors/text.xml
+++ b/general-concepts/mirrors/text.xml
@@ -72,8 +72,8 @@ you need to also bump the ebuild's revision.
 
 <p>
 More general information about the internals of mirroring can be found on <uri
-link="https://www.gentoo.org/proj/en/infrastructure/mirrors/overview-distfile.xml">infrastructure's
-pages</uri>.
+link="https://wiki.gentoo.org/wiki/Project:Infrastructure/Mirrors/Distfile_Mirroring_System">
+Infrastructure project's Distfile Mirroring System page</uri>.
 </p>
 </body>
 </subsection>

--- a/general-concepts/mirrors/text.xml
+++ b/general-concepts/mirrors/text.xml
@@ -33,9 +33,8 @@ certain files; files will still be downloaded from the original locations.
 
 <p>
 The <c>RESTRICT="primaryuri"</c> setting causes Portage to try
-original locations <e>first</e>, and then fall back to mirrors if necessary <d/> this
-is sometimes useful if approximate download counts are needed, or if upstream
-have a reliable mirror setup.
+original locations <e>first</e>, and then fall back to mirrors if necessary.
+This should not be used in new ebuilds.
 </p>
 
 <p>

--- a/general-concepts/mirrors/text.xml
+++ b/general-concepts/mirrors/text.xml
@@ -98,8 +98,14 @@ requirement of the license.
 
 <p>
 When you upload the file to <c>dev.gentoo.org:~/public_html</c>, you must ensure that it, and its
-parent directories, are world-readable.
+parent directories, are world-readable.  An example <c>SRC_URI</c> referencing
+a distfile mirrored this way follows:
 </p>
+
+<codesample lang="ebuild">
+SRC_URI="https://dev.gentoo.org/~myname/distfiles/${P}.tar.gz"
+</codesample>
+
 </body>
 </subsection>
 </section>


### PR DESCRIPTION
* discourage `RESTRICT=primaryuri`
* replace files via SRC_URI arrows instead of distfiles-local voodoo
* make it clearer that thirdpartymirrors should be used only if multiple ebuilds reference the same mirror group
* explain when thirdpartymirrors make sense, and when they're just a maintenance burden