### PR TITLE
ebuild-writing/file-format: discourage _pre for snapshots

### DIFF
--- a/ebuild-writing/file-format/text.xml
+++ b/ebuild-writing/file-format/text.xml
@@ -115,11 +115,14 @@ Overall, this gives us a filename like <c>libfoo-1.2.5b_pre5-r2.ebuild</c>.
 </p>
 
 <p>
-When packaging a snapshot of a source repository, there are two commonly used formats. The first
-treats the snapshot as a patch to the previous version, and so the ebuild version is in the format
-$(last-released-version)_pYYYYMMDD. Alternatively, the snapshot may be treated as a pre-release to
-an upcoming version, usually used when a release is anticipated but not out yet. The format for this
-is $(upcoming-version)_preYYYYMMDD.
+When packaging a snapshot of a source repository, treat the snapshot
+as a patch to the previous version, and so the ebuild version is in
+the format $(last-released-version)_pYYYYMMDD. Treating the snapshot
+as a pre-release to an upcoming version is strongly discouraged, as
+upstream may not always be reliable with their versioning scheme. The
+only exception to this rule is packaging a snapshot where no official
+upstream version exists, in which case the format would be
+0_preYYYYMMDD.
 </p>
 
 <p>


### PR DESCRIPTION
Do not discourage people to use the format _preYYYYMMDD when creating
snapshot ebuilds. This requires the developer to guess the version of
the next release by the upstream. The same snapshot can be treated as
a patch release over an existing version with the _pYYYYMMDD format,
which is more reliable.

Signed-off-by: Göktürk Yüksek <gokturk@gentoo.org>